### PR TITLE
Add version endpoint and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ python app.py --name Kenta
 pytest -q
 ```
 
+## Endpoints
+
+- `GET /health` returns `{ "status": "ok" }`
+- `GET /version` returns `{ "version": "1.0.0" }`
+
 ## Repository hygiene
 - All dependencies are pinned in `requirements.txt`.
 - CI runs linting and tests on every push/PR.

--- a/app.py
+++ b/app.py
@@ -11,6 +11,10 @@ def create_app() -> Flask:
     def health():
         return jsonify(status="ok")
 
+    @app.get("/version")
+    def version():
+        return jsonify(version="1.0.0")
+
     return app
 
 def main(argv=None) -> int:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -13,3 +13,12 @@ def test_health_endpoint():
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.get_json()["status"] == "ok"
+
+
+def test_version_endpoint():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get("/version")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["version"] == "1.0.0"


### PR DESCRIPTION
## Summary
- add `/version` endpoint exposing application version
- cover `/version` with unit tests and document available endpoints

## Testing
- `python -m pytest -q`
- `flake8` *(fails: command not found; attempted `pip install flake8` but it could not find a matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_6899e6e4d51c833098c37396e3763697