### PR TITLE
ci: install lint and test tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
           python-version: '3.11'
       - name: Install dependencies
         run: |
-    python -m pip install --upgrade pip
-    pip install -r requirements.txt
-    pip install flake8 pytest
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install flake8 pytest
       - name: Lint
         run: flake8
       - name: Test


### PR DESCRIPTION
## Summary
- ensure CI installs flake8 and pytest for linting and tests

## Testing
- `pip install -r requirements.txt`
- `pip install flake8 pytest` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8` *(fails: command not found)*
- `PYTHONPATH=. pytest tests/test_app.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6899ecb093e88330806185d538c01e5b